### PR TITLE
Fix for the 'Input' object being referentially compared in some places

### DIFF
--- a/src/Sprache.Tests/InputTests.cs
+++ b/src/Sprache.Tests/InputTests.cs
@@ -16,8 +16,9 @@ namespace Sprache.Tests
             var p = 2;
             var i1 = new Input(s, p);
             var i2 = new Input(s, p);
-            Assert.AreEqual(i1, i2);
-        }
+			Assert.AreEqual(i1, i2);
+			Assert.IsTrue(i1 == i2);
+		}
 
         [Test]
         public void InputsOnTheSameString_AtDifferentPositions_AreNotEqual()
@@ -26,7 +27,8 @@ namespace Sprache.Tests
             var i1 = new Input(s, 1);
             var i2 = new Input(s, 2);
             Assert.AreNotEqual(i1, i2);
-        }
+			Assert.IsTrue(i1 != i2);
+		}
 
         [Test]
         public void InputsOnDifferentStrings_AtTheSamePosition_AreNotEqual()

--- a/src/Sprache/Input.cs
+++ b/src/Sprache/Input.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Sprache
 {
-    public class Input
+    public class Input : IEquatable<Input>
     {
         public string Source { get; set; }
         readonly string _source;
@@ -50,16 +50,34 @@ namespace Sprache
         {
             return string.Format("Line {0}, Column {1}", _line, _column);
         }
-
-        public override bool Equals(object obj)
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return ((_source != null ? _source.GetHashCode() : 0) * 397) ^ _position;
+			}
+		}
+		public override bool Equals(object obj)
         {
-            var i = obj as Input;
-            return i != null && i._source == _source && i._position == _position;
+	        if (ReferenceEquals(null, obj)) return false;
+	        if (ReferenceEquals(this, obj)) return true;
+	        if (obj.GetType() != this.GetType()) return false;
+	        return Equals((Input) obj);
         }
 
-        public override int GetHashCode()
-        {
-            return _source.GetHashCode() ^ _position.GetHashCode();
-        }
+	    public bool Equals(Input other)
+	    {
+		    if (ReferenceEquals(null, other)) return false;
+		    if (ReferenceEquals(this, other)) return true;
+		    return string.Equals(_source, other._source) && _position == other._position;
+	    }
+	    public static bool operator ==(Input left, Input right)
+	    {
+		    return Equals(left, right);
+	    }
+	    public static bool operator !=(Input left, Input right)
+	    {
+		    return !Equals(left, right);
+	    }
     }
 }


### PR DESCRIPTION
The 'Input' class is designed like a value object, the „Equals“ method
is overriden, but in some cases it was mistakenly not used for
comparison. For instance, in the method „XOr<T>“ line „if
(ff.FailedInput != i)“ used reference comparison, where it seems must be
value comparison.

So I added assertions to the  tests, to test the eq. operators too, and
overrided the  operators to make tests succeed.
