### PR TITLE
adding a bit more visibility into why a parse fails

### DIFF
--- a/src/Sprache.Tests/ResultTests.cs
+++ b/src/Sprache.Tests/ResultTests.cs
@@ -16,5 +16,19 @@ namespace Sprache.Tests
             var r = (Result<IEnumerable<string>>)p.TryParse("x{");
             Assert.That(r.Message.Contains("unexpected '{'"));
         }
+
+        [Test]
+        public void FailureShowsNearbyParseResults()
+        {
+            var p = from a in Parse.Char('x')
+                    from b in Parse.Char('y')
+                    select string.Format("{0},{1}", a, b);
+
+            var r = (Result<string>)p.TryParse("x{");
+
+            const string expectedMessage = @"Parsing failure: unexpected '{'; expected y (Line 1, Column 2). recently consumed: x";
+
+            Assert.That(r.ToString(), Is.EqualTo(expectedMessage));
+        }
     }
 }

--- a/src/Sprache/Result.cs
+++ b/src/Sprache/Result.cs
@@ -90,7 +90,22 @@ namespace Sprache
             if (Expectations.Any())
                 expMsg = " expected " + Expectations.Aggregate((e1, e2) => e1 + " or " + e2);
 
-            return string.Format("Parsing failure: {0};{1} ({2}).", Message, expMsg, Remainder);
+            var recentlyConsumed = CalculateRecentlyConsumed();
+
+            return string.Format("Parsing failure: {0};{1} ({2}). recently consumed: {3}", Message, expMsg, Remainder, recentlyConsumed);
+        }
+
+        private string CalculateRecentlyConsumed()
+        {
+            const int windowSize = 10;
+
+            var totalConsumedChars = this.Remainder.Position;
+            var windowStart = totalConsumedChars - windowSize;
+            windowStart = windowStart < 0 ? 0 : windowStart;
+
+            var numberOfRecentlyConsumedChars = totalConsumedChars - windowStart;
+
+            return this.Remainder.Source.Substring(windowStart, numberOfRecentlyConsumedChars);
         }
     }
 }


### PR DESCRIPTION
Wonder what you folks think about something like this?

I don't need this format exactly, but it would help sometimes to be able to see something of the text that was recently parsed, to better visualize where the line,column is, exactly.

Beyond this, it would be useful to have an option to see the source replaced with the parse tokens.

this is a first try, please provide feedback on the direction.
