### PR TITLE
Added Sequence() and Contained() parsers

### DIFF
--- a/src/Sprache.Tests/ParseTests.cs
+++ b/src/Sprache.Tests/ParseTests.cs
@@ -302,5 +302,50 @@ namespace Sprache.Tests
             var ab = Parse.IgnoreCase("ab").Text();
             AssertParser.SucceedsWith(ab, "Ab", m => Assert.AreEqual("Ab", m));
         }
+
+        [Test]
+        public void RepeatParserConsumeInputOnSuccessfulMatch()
+        {
+            var repeated = Parse.Char('a').Repeat(3);
+            var r = repeated.TryParse("aaabbb");
+            Assert.IsTrue(r.WasSuccessful);
+            Assert.AreEqual(3, r.Remainder.Position);
+        }
+
+        [Test]
+        public void RepeatParserDoesntConsumeInputOnFailedMatch()
+        {
+            var repeated = Parse.Char('a').Repeat(3);
+            var r = repeated.TryParse("bbbaaa");
+            Assert.IsTrue(!r.WasSuccessful);
+            Assert.AreEqual(0, r.Remainder.Position);
+        }
+
+        [Test]
+        public void RepeatParserCanParseWithCountOfZero()
+        {
+            var repeated = Parse.Char('a').Repeat(0);
+            var r = repeated.TryParse("bbb");
+            Assert.IsTrue(r.WasSuccessful);
+            Assert.AreEqual(0, r.Remainder.Position);
+        }
+
+        [Test]
+        public void CanParseSequence()
+        {
+            var sequence = Parse.Char('a').DelimitedBy(Parse.Char(','));
+            var r = sequence.TryParse("a,a,a");
+            Assert.IsTrue(r.WasSuccessful);
+            Assert.IsTrue(r.Remainder.AtEnd);
+        }
+
+        [Test]
+        public void CanParseContained()
+        {
+            var parser = Parse.Char('a').Contained(Parse.Char('['), Parse.Char(']'));
+            var r = parser.TryParse("[a]");
+            Assert.IsTrue(r.WasSuccessful);
+            Assert.IsTrue(r.Remainder.AtEnd);
+        }
     }
 }

--- a/src/Sprache/Parse.Sequence.cs
+++ b/src/Sprache/Parse.Sequence.cs
@@ -1,0 +1,70 @@
+﻿namespace Sprache
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    partial class Parse
+    {
+        public static Parser<IEnumerable<T>> DelimitedBy<T, U>(this Parser<T> parser, Parser<U> delimiter)
+        {
+            if (parser == null) throw new ArgumentNullException("parser");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
+
+            return from head in parser.Once()
+                   from tail in
+                       (from separator in delimiter
+                        from item in parser
+                        select item).Many()
+                   select head.Concat(tail);
+        }
+
+        public static Parser<IEnumerable<T>> Repeat<T>(this Parser<T> parser, int count)
+        {
+            if (parser == null) throw new ArgumentNullException("parser");
+
+            return i =>
+            {
+                var remainder = i;
+                var result = new List<T>();
+
+                for (var n = 0; n < count; ++n)
+                {
+                    var r = parser(remainder);
+                    if (!r.WasSuccessful)
+                    {
+                        var what = r.Remainder.AtEnd
+                            ? "end of input"
+                            : r.Remainder.Current.ToString();
+
+                        var msg = string.Format("Unexpected '{0}'", what);
+                        var exp = string.Format("'{0}' {1} times, but was {2}", string.Join(", ", r.Expectations), count, n);
+                        return Result.Failure<IEnumerable<T>>(i, msg, new[] { exp });
+                    }
+
+                    if (remainder != r.Remainder)
+                    {
+                        result.Add(r.Value);
+                    }
+
+                    remainder = r.Remainder;
+                }
+
+                return Result.Success<IEnumerable<T>>(result, remainder);
+            };
+        }
+
+
+        public static Parser<T> Contained<T, U, V>(this Parser<T> parser, Parser<U> open, Parser<V> close)
+        {
+            if (parser == null) throw new ArgumentNullException("parser");
+            if (open == null) throw new ArgumentNullException("open");
+            if (close == null) throw new ArgumentNullException("close");
+
+            return from o in open
+                   from item in parser
+                   from c in close
+                   select item;
+        }
+    }
+}


### PR DESCRIPTION
This makes it a bit easier to implement things like parsing
arrays.

For example, to implement a simple numeric array literal like `[1,2,3]`:

``` c#
var arrayParser = Parse.Digit.DelimitedBy(Parse.Char(','))
                             .Contained(Parse.Char('['), Parse.Char(']'));
```
