### PR TITLE
Updated the link to Antlr in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This repository is a fork of Nicholas Blumhardt's Sprache Google Code repository
 
 Sprache is a simple, lightweight library for constructing parsers directly in C# code.
 
-It doesn't compete with "industrial strength" language workbenches - it fits somewhere in between regular expressions and a full-featured toolset like [ANTLR](antlr.org).
+It doesn't compete with "industrial strength" language workbenches - it fits somewhere in between regular expressions and a full-featured toolset like [ANTLR](http://antlr.org).
 
 Usage
 -----


### PR DESCRIPTION
When following the link to Antlr in the README while browsing the repository on GitHub, if the Url isn't designated as an external link it tries navigating to the a file in the local repository.
