### PR TITLE
Enable parsing with partial success and multiple observations (info, warnings, and errors)

### DIFF
--- a/src/Sprache.Tests/AssertParser.cs
+++ b/src/Sprache.Tests/AssertParser.cs
@@ -31,7 +31,7 @@ namespace Sprache.Tests
             parser.TryParse(input)
                 .IfFailure(f =>
                 {
-                    Assert.Fail("Parsing of \"{0}\" failed unexpectedly at position {1}: {2}", input, f.Remainder.Position, f.Message);
+                    Assert.Fail("Parsing of \"{0}\" failed unexpectedly at position {1}: {2}", input, f.Remainder.Position, String.Join(Environment.NewLine, f.Observations.Select(x => x.Message)));
                     return f;
                 })
                 .IfSuccess(s =>

--- a/src/Sprache.Tests/ResultTests.cs
+++ b/src/Sprache.Tests/ResultTests.cs
@@ -14,7 +14,7 @@ namespace Sprache.Tests
         {
             var p = Parse.String("xy").Text().XMany().End();
             var r = (Result<IEnumerable<string>>)p.TryParse("x{");
-            Assert.That(r.Message.Contains("unexpected '{'"));
+            Assert.That(r.Observations.Any(x => x.Message.Contains("unexpected '{'")));
         }
 
         [Test]
@@ -26,7 +26,7 @@ namespace Sprache.Tests
 
             var r = (Result<string>)p.TryParse("x{");
 
-            const string expectedMessage = @"Parsing failure: unexpected '{'; expected y (Line 1, Column 2). recently consumed: x";
+            const string expectedMessage = "Parsing failure. Recently consumed: 'x'. Observations: \r\nError: unexpected '{'";
 
             Assert.That(r.ToString(), Is.EqualTo(expectedMessage));
         }

--- a/src/Sprache/IResultOfT.cs
+++ b/src/Sprache/IResultOfT.cs
@@ -14,20 +14,15 @@ namespace Sprache
         T Value { get; }
 
         /// <summary>
-        /// Gets a value indicating whether wether parsing was successful.
+        /// Gets a value indicating whether parsing was successful.
         /// </summary>
         bool WasSuccessful { get; }
 
         /// <summary>
-        /// Gets the error message.
+        /// Gets any observations as a result of parsing.
         /// </summary>
-        string Message { get; }
-
-        /// <summary>
-        /// Gets the parser expectations in case of error.
-        /// </summary>
-        IEnumerable<string> Expectations { get; }
-
+        IEnumerable<ResultObservation> Observations { get; }
+            
         /// <summary>
         /// Gets the remainder of the input.
         /// </summary>

--- a/src/Sprache/Observe.cs
+++ b/src/Sprache/Observe.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+
+namespace Sprache
+{
+    /// <summary>
+    /// Helps create ResultObservation object
+    /// </summary>
+    public static class Observe
+    {
+        /// <summary>
+        /// Creates a ResultObservation with a severity of Info.
+        /// </summary>
+        /// <param name="message">The observation's message</param>
+        /// <param name="expectations">The parse expectations</param>
+        /// <returns>The observation</returns>
+        public static ResultObservation Info(string message, params string[] expectations) { return Info(message, (IEnumerable<string>)expectations); }
+
+        /// <summary>
+        /// Creates a ResultObservation with a severity of Warning.
+        /// </summary>
+        /// <param name="message">The observation's message</param>
+        /// <param name="expectations">The parse expectations</param>
+        /// <returns>The observation</returns>
+        public static ResultObservation Warning(string message, params string[] expectations) { return Warning(message, (IEnumerable<string>)expectations); }
+
+        /// <summary>
+        /// Creates a ResultObservation with a severity of Error.
+        /// </summary>
+        /// <param name="message">The observation's message</param>
+        /// <param name="expectations">The parse expectations</param>
+        /// <returns>The observation</returns>
+        public static ResultObservation Error(string message, params string[] expectations) { return Error(message, (IEnumerable<string>)expectations); }
+
+        /// <summary>
+        /// Creates a ResultObservation with a severity of Info.
+        /// </summary>
+        /// <param name="message">The observation's message</param>
+        /// <param name="expectations">The parse expectations</param>
+        /// <returns>The observation</returns>
+        public static ResultObservation Info(string message, IEnumerable<string> expectations) { return new ResultObservation(ResultObservationSeverity.Info, message, expectations); }
+
+        /// <summary>
+        /// Creates a ResultObservation with a severity of Warning.
+        /// </summary>
+        /// <param name="message">The observation's message</param>
+        /// <param name="expectations">The parse expectations</param>
+        /// <returns>The observation</returns>
+        public static ResultObservation Warning(string message, IEnumerable<string> expectations) { return new ResultObservation(ResultObservationSeverity.Warning, message, expectations); }
+
+        /// <summary>
+        /// Creates a ResultObservation with a severity of Error.
+        /// </summary>
+        /// <param name="message">The observation's message</param>
+        /// <param name="expectations">The parse expectations</param>
+        /// <returns>The observation</returns>
+        public static ResultObservation Error(string message, IEnumerable<string> expectations) { return new ResultObservation(ResultObservationSeverity.Error, message, expectations); }
+    }
+}

--- a/src/Sprache/Parse.Regex.cs
+++ b/src/Sprache/Parse.Regex.cs
@@ -53,11 +53,11 @@ namespace Sprache
                                     : string.Format("`{0}'", input[match.Index]);
                     return Result.Failure<string>(
                         remainder,
-                        "string matching regex `" + regex.ToString() + "' expected but " + found + " found",
-                        expectations);
+                        Observe.Error("string matching regex `" + regex.ToString() + "' expected but " + found + " found", expectations));
                 }
 
-                return Result.Failure<string>(i, "Unexpected end of input", expectations);
+                return Result.Failure<string>(i,
+                    Observe.Error("Unexpected end of input", expectations));
             };
         }
     }

--- a/src/Sprache/Parse.Sequence.cs
+++ b/src/Sprache/Parse.Sequence.cs
@@ -38,8 +38,9 @@
                             : r.Remainder.Current.ToString();
 
                         var msg = string.Format("Unexpected '{0}'", what);
-                        var exp = string.Format("'{0}' {1} times, but was {2}", string.Join(", ", r.Expectations), count, n);
-                        return Result.Failure<IEnumerable<T>>(i, msg, new[] { exp });
+                        var exp = string.Format("'{0}' {1} times, but was {2}", string.Join(", ", r.Observations.SelectMany(x => x.Expectations)), count, n);
+                        return Result.Failure<IEnumerable<T>>(i, 
+                            Observe.Error(msg, exp));
                     }
 
                     if (remainder != r.Remainder)

--- a/src/Sprache/Parse.cs
+++ b/src/Sprache/Parse.cs
@@ -28,14 +28,12 @@ namespace Sprache
                     if (predicate(i.Current))
                         return Result.Success(i.Current, i.Advance());
 
-                    return Result.Failure<char>(i,
-                        string.Format("unexpected '{0}'", i.Current),
-                        new[] { description });
+                    return Result.Failure<char>(i, 
+                        Observe.Error(string.Format("unexpected '{0}'", i.Current), description));
                 }
 
                 return Result.Failure<char>(i,
-                    "Unexpected end of input reached",
-                    new[] { description });
+                    Observe.Error("Unexpected end of input reached", description));
             };
         }
 
@@ -213,8 +211,8 @@ namespace Sprache
 
                 if (result.WasSuccessful)
                 {
-                    var msg = string.Format("`{0}' was not expected", string.Join(", ", result.Expectations));
-                    return Result.Failure<object>(i, msg, new string[0]);
+                    var msg = string.Format("'{0}' was not expected", string.Join(", ", result.Observations.SelectMany(x => x.Expectations)));
+                    return Result.Failure<object>(i, Observe.Error(msg));
                 }
                 return Result.Success<object>(null, i);
             };
@@ -234,6 +232,23 @@ namespace Sprache
             if (second == null) throw new ArgumentNullException("second");
 
             return i => first(i).IfSuccess(s => second(s.Value)(s.Remainder));
+        }
+
+        /// <summary>
+        /// Parses, but does not consume the input
+        /// </summary>
+        /// <param name="parser"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Parser<T> LookAhead<T>(this Parser<T> parser)
+        {
+            return input =>
+            {
+                var results = parser(input);
+                return results.WasSuccessful
+                    ? Result.Success(results.Value, input, results.Observations)
+                    : results;
+            };
         }
 
         /// <summary>
@@ -264,6 +279,63 @@ namespace Sprache
                 }
 
                 return Result.Success<IEnumerable<T>>(result, remainder);
+            };
+        }
+
+        /// <summary>
+        /// Parse a stream of elements, attemting to skip over invalid elements.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="parser"></param>
+        /// <returns></returns>
+        /// <remarks>Implemented imperatively to decrease stack usage.</remarks>
+        public static Parser<IEnumerable<T>> ManyWithPanic<T, U>(this Parser<T> parser, Parser<U> panicUntil, string elementDescription)
+        {
+            if (parser == null) throw new ArgumentNullException("parser");
+            if (panicUntil == null) throw new ArgumentNullException("panicUntil");
+
+            return i =>
+            {
+                var remainder = i;
+                var result = new List<T>();
+                var observations = new List<ResultObservation>();
+
+                var r = parser(i);
+
+                while (true)
+                {
+                    if (r.WasSuccessful && remainder == r.Remainder)
+                        break;
+
+                    if (!r.WasSuccessful)
+                    {
+                        if (remainder == r.Remainder)
+                            break;
+
+                        observations.Add(Observe.Error("Unexpected {0}.", elementDescription));
+
+                        remainder = r.Remainder;
+
+                        var panicResult = panicUntil(remainder);
+
+                        while (!panicResult.WasSuccessful && !remainder.AtEnd)
+                        {
+                            remainder = remainder.Advance();
+                            panicResult = panicUntil(remainder);
+                        }
+
+                        remainder = panicResult.Remainder;
+                    }
+                    else
+                    {
+                        result.Add(r.Value);
+                        remainder = r.Remainder;    
+                    }
+
+                    r = parser(remainder);
+                }
+
+                return Result.Success<IEnumerable<T>>(result, remainder, observations);
             };
         }
 
@@ -321,10 +393,9 @@ namespace Sprache
             return i => parser(i).IfSuccess(s =>
                 s.Remainder.AtEnd 
                     ? s
-                    : Result.Failure<T>(
-                        s.Remainder,
-                        string.Format("unexpected '{0}'", s.Remainder.Current),
-                        new[] { "end of input" }));
+                    : Result.Failure<T>(s.Remainder,
+                        Observe.Error(string.Format("unexpected '{0}'", s.Remainder.Current),
+                                      "end of input")));
         }
 
         /// <summary>
@@ -380,8 +451,8 @@ namespace Sprache
                                throw new ParseException(i.Memos[p].ToString());
 
                            i.Memos[p] = Result.Failure<T>(i,
-                               "Left recursion in the grammar.",
-                               new string[0]);
+                               Observe.Error("Left recursion in the grammar."));
+
                            var result = p(i);
                            i.Memos[p] = result;
                            return result;
@@ -417,8 +488,7 @@ namespace Sprache
                 {
                     return second(i).IfFailure(sf => Result.Failure<T>(
                         fr.Remainder,
-                        fr.Message,
-                        fr.Expectations.Union(sf.Expectations)));
+                        fr.Observations.Union(sf.Observations)));
                 }
                 
                 if (fr.Remainder == i)
@@ -441,7 +511,7 @@ namespace Sprache
             if (name == null) throw new ArgumentNullException("name");
 
             return i => parser(i).IfFailure(f => f.Remainder == i ?
-                Result.Failure<T>(f.Remainder, f.Message, new[] { name }) :
+                Result.Failure<T>(f.Remainder, f.Observations.Concat(new[]{Observe.Error(string.Format("Rule named '{0}' failed.", name))})) :
                 f);
         }
 
@@ -467,8 +537,7 @@ namespace Sprache
 
                     return second(i).IfFailure(sf => Result.Failure<T>(
                         fr.Remainder,
-                        fr.Message,
-                        fr.Expectations.Union(sf.Expectations)));
+                        fr.Observations.Concat(sf.Observations)));
                 }
 
                 if (fr.Remainder == i)
@@ -549,7 +618,8 @@ namespace Sprache
                 {
                     var r = except(i);
                     if (r.WasSuccessful)
-                        return Result.Failure<T>(i, "Excepted parser succeeded.", new[] { "other than the excepted input" });
+                        return Result.Failure<T>(i, 
+                            Observe.Error("Excepted parser succeeded.", "other than the excepted input" ));
                     return parser(i);
                 };
         }
@@ -582,8 +652,7 @@ namespace Sprache
 
             return i => parser(i).IfSuccess(s =>
                 predicate(s.Value) ? s : Result.Failure<T>(i,
-                    string.Format("Unexpected {0}.", s.Value),
-                    new string[0]));
+                    Observe.Error(string.Format("Unexpected {0}.", s.Value))));
         }
 
         /// <summary>

--- a/src/Sprache/Result.cs
+++ b/src/Sprache/Result.cs
@@ -15,10 +15,24 @@ namespace Sprache
         /// <typeparam name="T">The type of the result (value).</typeparam>
         /// <param name="value">The sucessfully parsed value.</param>
         /// <param name="remainder">The remainder of the input.</param>
+        /// <param name="observations">The resulting observations.</param>
         /// <returns>The new <see cref="IResult&lt;T&gt;"/>.</returns>
-        public static IResult<T> Success<T>(T value, Input remainder)
+        public static IResult<T> Success<T>(T value, Input remainder, params ResultObservation[] observations)
         {
-            return new Result<T>(value, remainder);
+            return Success(value, remainder, (IEnumerable<ResultObservation>) observations);
+        }
+
+        /// <summary>
+        /// Creates a success result.
+        /// </summary>
+        /// <typeparam name="T">The type of the result (value).</typeparam>
+        /// <param name="value">The sucessfully parsed value.</param>
+        /// <param name="remainder">The remainder of the input.</param>
+        /// <param name="observations">The resulting observations.</param>
+        /// <returns>The new <see cref="IResult&lt;T&gt;"/>.</returns>
+        public static IResult<T> Success<T>(T value, Input remainder, IEnumerable<ResultObservation> observations)
+        {
+            return new Result<T>(value, remainder, observations);
         }
 
         /// <summary>
@@ -26,12 +40,23 @@ namespace Sprache
         /// </summary>
         /// <typeparam name="T">The type of the result.</typeparam>
         /// <param name="remainder">The remainder of the input.</param>
-        /// <param name="message">The error message.</param>
-        /// <param name="expectations">The parser expectations.</param>
+        /// <param name="observations">The resulting observations.</param>
         /// <returns>The new <see cref="IResult&lt;T&gt;"/>.</returns>
-        public static IResult<T> Failure<T>(Input remainder, string message, IEnumerable<string> expectations)
+        public static IResult<T> Failure<T>(Input remainder, params ResultObservation[] observations)
         {
-            return new Result<T>(remainder, message, expectations);
+            return Failure<T>(remainder, (IEnumerable<ResultObservation>)observations);
+        }
+
+        /// <summary>
+        /// Creates a failure result.
+        /// </summary>
+        /// <typeparam name="T">The type of the result.</typeparam>
+        /// <param name="remainder">The remainder of the input.</param>
+        /// <param name="observations">The resulting observations.</param>
+        /// <returns>The new <see cref="IResult&lt;T&gt;"/>.</returns>
+        public static IResult<T> Failure<T>(Input remainder,  IEnumerable<ResultObservation> observations)
+        {
+            return new Result<T>(remainder, observations);
         }
     }
 
@@ -40,25 +65,22 @@ namespace Sprache
         private readonly T _value;
         private readonly Input _remainder;
         private readonly bool _wasSuccessful;
-        private readonly string _message;
-        private readonly IEnumerable<string> _expectations;
+        private readonly ResultObservation[] _observations;
 
-        public Result(T value, Input remainder)
+        public Result(T value, Input remainder, IEnumerable<ResultObservation> observations)
         {
             _value = value;
             _remainder = remainder;
             _wasSuccessful = true;
-            _message = null;
-            _expectations = Enumerable.Empty<string>();
+            _observations = observations.ToArray();
         }
 
-        public Result(Input remainder, string message, IEnumerable<string> expectations)
+        public Result(Input remainder, IEnumerable<ResultObservation> observations)
         {
             _value = default(T);
             _remainder = remainder;
             _wasSuccessful = false;
-            _message = message;
-            _expectations = expectations;
+            _observations = observations.ToArray();
         }
 
         public T Value
@@ -74,25 +96,39 @@ namespace Sprache
 
         public bool WasSuccessful { get { return _wasSuccessful; } }
 
-        public string Message { get { return _message; } }
-
-        public IEnumerable<string> Expectations { get { return _expectations; } }
+        public IEnumerable<ResultObservation> Observations { get { return _observations; }}
 
         public Input Remainder { get { return _remainder; } }
 
         public override string ToString()
         {
-            if (WasSuccessful)
-                return string.Format("Successful parsing of {0}.", Value);
+            string intro;
 
-            var expMsg = "";
+            if (!WasSuccessful)
+            {
+                var recentlyConsumed = CalculateRecentlyConsumed();
+                intro = string.Format("Parsing failure. Recently consumed: '{0}'.", recentlyConsumed);
+            }
+            else
+            {
+                intro = string.Format("Successful parsing of {0}.", Value);
+            }
 
-            if (Expectations.Any())
-                expMsg = " expected " + Expectations.Aggregate((e1, e2) => e1 + " or " + e2);
+            string observations = string.Join(Environment.NewLine, Observations
+                .Select(x => string.Format("{0}: {1}", SeverityToString(x.Severity), x.Message)));
 
-            var recentlyConsumed = CalculateRecentlyConsumed();
+            return String.Format("{0} Observations: {2}{1}", intro , observations, Environment.NewLine);
+        }
 
-            return string.Format("Parsing failure: {0};{1} ({2}). recently consumed: {3}", Message, expMsg, Remainder, recentlyConsumed);
+        private string SeverityToString(ResultObservationSeverity severity)
+        {
+            switch (severity)
+            {
+                case ResultObservationSeverity.Info: return "Info";
+                case ResultObservationSeverity.Warning: return "Warning";
+                case ResultObservationSeverity.Error: return "Error";
+                default: return "Observation";
+            }
         }
 
         private string CalculateRecentlyConsumed()
@@ -105,7 +141,7 @@ namespace Sprache
 
             var numberOfRecentlyConsumedChars = totalConsumedChars - windowStart;
 
-            return this.Remainder.Source.Substring(windowStart, numberOfRecentlyConsumedChars);
+            return Remainder.Source.Substring(windowStart, numberOfRecentlyConsumedChars);
         }
     }
 }

--- a/src/Sprache/ResultHelper.cs
+++ b/src/Sprache/ResultHelper.cs
@@ -11,7 +11,7 @@ namespace Sprache
             if (result.WasSuccessful)
                 return next(result);
 
-            return Result.Failure<U>(result.Remainder, result.Message, result.Expectations);
+            return Result.Failure<U>(result.Remainder, result.Observations);
         }
 
         public static IResult<T> IfFailure<T>(this IResult<T> result, Func<IResult<T>, IResult<T>> next)

--- a/src/Sprache/ResultObservation.cs
+++ b/src/Sprache/ResultObservation.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Sprache
+{
+    /// <summary>
+    /// Represents an observation of the results of a parse attempt.
+    /// </summary>
+    public class ResultObservation
+    {
+        private readonly ResultObservationSeverity _severity;
+        private readonly string _message;
+        private readonly string[] _expectations;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="severity">The severity of the observation</param>
+        /// <param name="message">The observation's message</param>
+        /// <param name="expectations">The parse expectations</param>
+        /// <exception cref="ArgumentException"></exception>
+        public ResultObservation(ResultObservationSeverity severity, string message, IEnumerable<string> expectations)
+        {
+            if(string.IsNullOrWhiteSpace(message)) throw new ArgumentException("You must provide a message.", "message");
+
+            _severity = severity;
+            _message = message;
+            _expectations = expectations != null
+                ? expectations.Where(x => x != null).ToArray()
+                : new string[0];
+        }
+
+        /// <summary>
+        /// The severity of the observation.
+        /// </summary>
+        public ResultObservationSeverity Severity { get { return _severity; } }
+
+        /// <summary>
+        /// The observation's message.
+        /// </summary>
+        public string Message { get { return _message; } }
+
+        /// <summary>
+        /// The parse expectations.
+        /// </summary>
+        public IEnumerable<string> Expectations { get { return _expectations; } }
+    }
+}

--- a/src/Sprache/ResultObservationSeverity.cs
+++ b/src/Sprache/ResultObservationSeverity.cs
@@ -1,0 +1,23 @@
+﻿namespace Sprache
+{
+    /// <summary>
+    /// Represents the severity of parsing observations
+    /// </summary>
+    public enum ResultObservationSeverity
+    {
+        /// <summary>
+        /// Indicates the observation is for informational purposes.
+        /// </summary>
+        Info,
+
+        /// <summary>
+        /// Indicates the observation is a warning.
+        /// </summary>
+        Warning,
+
+        /// <summary>
+        /// Indicates the observation is an error.
+        /// </summary>
+        Error
+    }
+}

--- a/src/Sprache/Sprache.csproj
+++ b/src/Sprache/Sprache.csproj
@@ -96,6 +96,7 @@
       <Link>Properties\Version.cs</Link>
     </Compile>
     <Compile Include="Input.cs" />
+    <Compile Include="Observe.cs" />
     <Compile Include="Option.cs" />
     <Compile Include="IPositionAware.cs" />
     <Compile Include="Parse.cs" />
@@ -107,6 +108,8 @@
     <Compile Include="IResultOfT.cs" />
     <Compile Include="Result.cs" />
     <Compile Include="ResultHelper.cs" />
+    <Compile Include="ResultObservation.cs" />
+    <Compile Include="ResultObservationSeverity.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">


### PR DESCRIPTION
Note: I don't want this to be merged into the mainline yet. I want the Sprache community to discuss this idea.

One limitation of Sprache that I find frustrating is: once it hits it's first error it just stops parsing.  A simple error recovery strategy that could be applied is to go into a "panic mode" - essentially when the parser fails, start consuming input until some "synchronization" token is parsed (e.g. in C-style language it could be the semi-colon or closing-brace characters).  In order to enable this, I believe there would need to be some (invasive?) changes to the Sprache API.

I've implemented a rough pass at the changes for everyone to take a look at and weigh in.  I still think the API needs some cleanup and consolidation. Also, I think the internals of the various parsers and parser extensions methods would need to be refreshed to reflect better support of the new API.  Finally, I think position information should be available on the observations - just haven't made the changes yet.

Take a look at the IResult<T> interface changes, the new ResultObservation and Observe classes, and the ManyWithPanic parser extension method (there is a test to show this in action).

Thoughts?