### PR TITLE
fixed Whitespace->WhiteSpace in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ A simple parser might parse a sequence of characters:
 Sprache provides a number of built-in functions that can make bigger parsers from smaller ones, often callable via Linq query comprehensions:
 
     Parser<string> identifier =
-        from leading in Parse.Whitespace.Many()
+        from leading in Parse.WhiteSpace.Many()
         from first in Parse.Letter.Once()
         from rest in Parse.LetterOrDigit.Many()
-        from trailing in Parse.Whitespace.Many()
+        from trailing in Parse.WhiteSpace.Many()
         select new string(first.Concat(rest).ToArray());
 
     var id = identifier.Parse(" abc123  ");


### PR DESCRIPTION
Just fixed the member name in the example of the readme file.
