### PR TITLE
Restoring Version.cs to Sprache project and bumping the version.

### DIFF
--- a/src/Sprache/Sprache.csproj
+++ b/src/Sprache/Sprache.csproj
@@ -54,6 +54,9 @@
     <Compile Include="Result.cs" />
     <Compile Include="ResultHelper.cs" />
     <Compile Include="StringExtensions.cs" />
+    <Compile Include="..\Version.cs">
+      <Link>Properties\Version.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Version.cs
+++ b/src/Version.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("1.10.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
 
 // 1.10.0.*     Added MSbuild process for CI (GitHub, TeamCity.CodeBetter.com, NuGet.org)


### PR DESCRIPTION
This PR reinstates _Version.cs_ as a linked file in the _Sprache_ project file, which I erroneously removed in my PCL PR. I also took the liberty of bumping the version to 2.0, which to me seems reasonable and inline with semantic versioning practices given that moving to a PCL is a large and potentially breaking change.
