### PR TITLE
Comment Parser

### DIFF
--- a/src/Sprache.Tests/Scenarios/AssemblerTests.cs
+++ b/src/Sprache.Tests/Scenarios/AssemblerTests.cs
@@ -23,8 +23,7 @@ namespace Sprache.Tests.Scenarios
             from operands in AsmToken(Identifier).XDelimitedBy(Parse.Char(','))
             select Tuple.Create(instructionName, operands.ToArray());
 
-        public static Parser<string> Comment =
-            AsmToken(Parse.EndOfLineComment(";"));
+        public static CommentParser Comment = new CommentParser() { Single = ";" };
 
         public static Parser<string> LabelId =
             Parse.Identifier(Parse.Letter.Or(Parse.Chars("._?")), Parse.LetterOrDigit.Or(Parse.Chars("_@#$~.?")));
@@ -37,7 +36,7 @@ namespace Sprache.Tests.Scenarios
         public static readonly Parser<IEnumerable<AssemblerLine>> Assembler = (
             from label in Label.Optional()
             from instruction in Instruction.Optional()
-            from comment in Comment.Optional()
+            from comment in AsmToken(Comment.SingleLineComment).Optional()
             from lineTerminator in Parse.LineTerminator
             select new AssemblerLine(
                 label.GetOrDefault(),
@@ -150,7 +149,7 @@ namespace Sprache.Tests.Scenarios
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != this.GetType()) return false;
-            return Equals((AssemblerLine) obj);
+            return Equals((AssemblerLine)obj);
         }
 
         public override int GetHashCode()
@@ -158,9 +157,9 @@ namespace Sprache.Tests.Scenarios
             unchecked
             {
                 var hashCode = (Label != null ? Label.GetHashCode() : 0);
-                hashCode = (hashCode*397) ^ (InstructionName != null ? InstructionName.GetHashCode() : 0);
-                hashCode = (hashCode*397) ^ (Operands != null ? Operands.GetHashCode() : 0);
-                hashCode = (hashCode*397) ^ (Comment != null ? Comment.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (InstructionName != null ? InstructionName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Operands != null ? Operands.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Comment != null ? Comment.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/src/Sprache/CommentParser.cs
+++ b/src/Sprache/CommentParser.cs
@@ -8,7 +8,7 @@ namespace Sprache
     /// <summary>
     /// Constructs customizable comment parsers.
     /// </summary>
-    public class CommentParser
+    public class CommentParser : IComment
     {
         ///<summary>
         ///Single-line comment header.

--- a/src/Sprache/CommentParser.cs
+++ b/src/Sprache/CommentParser.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sprache
+{
+    /// <summary>
+    /// Constructs customizable comment parsers.
+    /// </summary>
+    public class CommentParser
+    {
+        ///<summary>
+        ///Single-line comment header.
+        ///</summary>
+        public string Single { get; set; }
+
+        ///<summary>
+        ///Newline character preference.
+        ///</summary>
+        public string NewLine { get; set; }
+
+        ///<summary>
+        ///Multi-line comment opener.
+        ///</summary>
+        public string MultiOpen { get; set; }
+
+        ///<summary>
+        ///Multi-line comment closer.
+        ///</summary>
+        public string MultiClose { get; set; }
+
+        /// <summary>
+        /// Initializes a Comment with C-style headers and Windows newlines.
+        /// </summary>
+        public CommentParser()
+        {
+            Single = "//";
+            MultiOpen = "/*";
+            MultiClose = "*/";
+            NewLine = "\r\n";
+        }
+
+        /// <summary>
+        /// Initializes a Comment with custom headers newline characters.
+        /// </summary>
+        /// <param name="single"></param>
+        /// <param name="multiOpen"></param>
+        /// <param name="multiClose"></param>
+        /// <param name="newLine"></param>
+        public CommentParser(string single, string multiOpen, string multiClose, string newLine = "\r\n")
+        {
+            Single = single;
+            MultiOpen = multiOpen;
+            MultiClose = multiClose;
+            newLine = NewLine;
+        }
+
+        ///<summary>
+        ///Parse a single-line comment.
+        ///</summary>
+        public Parser<string> SingleLineComment
+        {
+            get
+            {
+                if (Single == null)
+                    throw new ParseException("Field 'Single' is null; single-line comments not allowed.");
+
+                return from first in Parse.String(Single)
+                       from rest in Parse.CharExcept("\r\n").Many().Text()
+                       select rest;
+            }
+            private set { }
+        }
+
+        ///<summary>
+        ///Parse a multi-line comment.
+        ///</summary>
+        public Parser<string> MultiLineComment
+        {
+            get
+            {
+                if (MultiOpen == null)
+                    throw new ParseException("Field 'MultiOpen' is null; multi-line comments not allowed.");
+                else if (MultiClose == null)
+                    throw new ParseException("Field 'MultiClose' is null; multi-line comments not allowed.");
+
+                return from first in Parse.String(MultiOpen)
+                       from rest in Parse.AnyChar
+                                    .Until(Parse.String(MultiClose)).Text()
+                       select rest;
+            }
+            private set { }
+        }
+
+        ///<summary>
+        ///Parse a comment.
+        ///</summary>
+        public Parser<string> AnyComment
+        {
+            get
+            {
+                if (Single != null && MultiOpen != null && MultiClose != null)
+                    return SingleLineComment.Or(MultiLineComment);
+                else if (Single != null && (MultiOpen == null || MultiClose == null))
+                    return SingleLineComment;
+                else if (Single == null && (MultiOpen != null && MultiClose != null))
+                    return MultiLineComment;
+                else throw new ParseException("Unable to parse comment; check values of fields 'MultiOpen' and 'MultiClose'.");
+            }
+            private set { }
+        }
+    }
+}

--- a/src/Sprache/CommentParser.cs
+++ b/src/Sprache/CommentParser.cs
@@ -38,22 +38,37 @@ namespace Sprache
             Single = "//";
             MultiOpen = "/*";
             MultiClose = "*/";
-            NewLine = "\r\n";
+            NewLine = "\n";
         }
 
         /// <summary>
-        /// Initializes a Comment with custom headers newline characters.
+        /// Initializes a Comment with custom multi-line headers and newline characters.
+        /// Single-line headers are made null, it is assumed they would not be used.
+        /// </summary>
+        /// <param name="multiOpen"></param>
+        /// <param name="multiClose"></param>
+        /// <param name="newLine"></param>
+        public CommentParser(string multiOpen, string multiClose, string newLine = "\n")
+        {
+            Single = null;
+            MultiOpen = multiOpen;
+            MultiClose = multiClose;
+            NewLine = newLine;
+        }
+
+        /// <summary>
+        /// Initializes a Comment with custom headers and newline characters.
         /// </summary>
         /// <param name="single"></param>
         /// <param name="multiOpen"></param>
         /// <param name="multiClose"></param>
         /// <param name="newLine"></param>
-        public CommentParser(string single, string multiOpen, string multiClose, string newLine = "\r\n")
+        public CommentParser(string single, string multiOpen, string multiClose, string newLine = "\n")
         {
             Single = single;
             MultiOpen = multiOpen;
             MultiClose = multiClose;
-            newLine = NewLine;
+            NewLine = newLine;
         }
 
         ///<summary>
@@ -67,7 +82,7 @@ namespace Sprache
                     throw new ParseException("Field 'Single' is null; single-line comments not allowed.");
 
                 return from first in Parse.String(Single)
-                       from rest in Parse.CharExcept("\r\n").Many().Text()
+                       from rest in Parse.CharExcept(NewLine).Many().Text()
                        select rest;
             }
             private set { }

--- a/src/Sprache/IComment.cs
+++ b/src/Sprache/IComment.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sprache
+{
+    interface IComment
+    {
+        ///<summary>
+        ///Single-line comment header.
+        ///</summary>
+        string Single { get; set; }
+
+        ///<summary>
+        ///Newline character preference.
+        ///</summary>
+        string NewLine { get; set; }
+
+        ///<summary>
+        ///Multi-line comment opener.
+        ///</summary>
+        string MultiOpen { get; set; }
+
+        ///<summary>
+        ///Multi-line comment closer.
+        ///</summary>
+        string MultiClose { get; set; }
+
+        ///<summary>
+        ///Parse a single-line comment.
+        ///</summary>
+        Parser<string> SingleLineComment { get; }
+
+        ///<summary>
+        ///Parse a multi-line comment.
+        ///</summary>
+        Parser<string> MultiLineComment { get; }
+
+        ///<summary>
+        ///Parse a comment.
+        ///</summary>
+        Parser<string> AnyComment { get; }
+    }
+}

--- a/src/Sprache/Parse.Primitives.cs
+++ b/src/Sprache/Parse.Primitives.cs
@@ -21,19 +21,6 @@
                 .Named("LineTerminator");
 
         /// <summary>
-        /// Parser for single line comment. Doesn't contain tail line ending
-        /// </summary>
-        /// <param name="commentStart">Symbols to start comment. I.e. "//" for C#, "#" for perl, ";" for assembler</param>
-        /// <returns></returns>
-        public static Parser<string> EndOfLineComment(string commentStart)
-        {
-            return
-                from start in String(commentStart)
-                from comment in CharExcept("\r\n").Many().Text()
-                select comment;
-        }
-
-        /// <summary>
         /// Parser for identifier starting with <paramref name="firstLetterParser"/> and continuing with <paramref name="tailLetterParser"/>
         /// </summary>
         public static Parser<string> Identifier(Parser<char> firstLetterParser, Parser<char> tailLetterParser)

--- a/src/Sprache/Sprache.csproj
+++ b/src/Sprache/Sprache.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommentParser.cs" />
+    <Compile Include="IComment.cs" />
     <Compile Include="IInput.cs" />
     <Compile Include="Input.cs" />
     <Compile Include="IPositionAware.cs" />

--- a/src/Sprache/Sprache.csproj
+++ b/src/Sprache/Sprache.csproj
@@ -36,6 +36,7 @@
     <!-- A reference to the entire .NET Framework is automatically included -->
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommentParser.cs" />
     <Compile Include="IInput.cs" />
     <Compile Include="Input.cs" />
     <Compile Include="IPositionAware.cs" />

--- a/src/XmlExample/TestFile.xml
+++ b/src/XmlExample/TestFile.xml
@@ -1,0 +1,7 @@
+﻿<body>
+  <p>
+    hello,<br/> <!--
+      This is a comment
+    --><i>world!</i>
+  </p>
+</body>

--- a/src/XmlExample/XmlExample.csproj
+++ b/src/XmlExample/XmlExample.csproj
@@ -129,6 +129,11 @@
       <Name>Sprache</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="TestFile.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
I wanted to share my solution to the problem discussed in [this issue](https://github.com/sprache/Sprache/issues/29) regarding comment parsing. I created this CommentParser class, which provides the user with a few comment parsers which will work with whichever headers they require. I removed the EndOfLineComment parser in Parse.Primitives.cs (as this CommentParser class achieves the same goal), and updated AssemblerTests to use the CommentParser class instead of that EndOfLineComment parser. I also modified the Xml Example to parse and ignore comments using CommentParser, so as to demonstrate the use of the class.