### PR TITLE
Resolves #36 by introducing a culture-invariant DecimalInvariant parser

### DIFF
--- a/src/Sprache.Tests/DecimalTests.cs
+++ b/src/Sprache.Tests/DecimalTests.cs
@@ -8,6 +8,7 @@ namespace Sprache.Tests
     public class DecimalTests
     {
         private static readonly Parser<string> DecimalParser = Parse.Decimal.End();
+        private static readonly Parser<string> DecimalInvariantParser = Parse.DecimalInvariant.End();
 
         private CultureInfo _previousCulture;
 
@@ -49,5 +50,12 @@ namespace Sprache.Tests
         {
             DecimalParser.Parse("1A.5");
         }
+
+        [Test]
+        public void LeadingDigitsInvariant()
+        {
+            Assert.AreEqual("12.23", DecimalInvariantParser.Parse("12.23"));
+        }
+
     }
 }

--- a/src/Sprache.Tests/ParseTests.cs
+++ b/src/Sprache.Tests/ParseTests.cs
@@ -153,12 +153,6 @@ namespace Sprache.Tests
              select first.Concat(rest))
             .Or(Parse.Char('a').Once());
 
-        [Test, Ignore("Not Implemented")]
-        public void CanParseLeftRecursiveGrammar()
-        {
-            AssertParser.SucceedsWith(ASeq.End(), "a,a,a", r => Assert.AreEqual(new string(r.ToArray()), "aaa"));
-        }
-
         [Test]
         public void DetectsLeftRecursion()
         {
@@ -176,12 +170,6 @@ namespace Sprache.Tests
              from rest in Parse.Char('b').Once()
              select first.Concat(rest))
             .Or(Parse.Char('b').Once());
-
-        [Test, Ignore("Not Implemented")]
-        public void CanParseMutuallyLeftRecursiveGrammar()
-        {
-            AssertParser.SucceedsWithAll(ABSeq.End(), "baba");
-        }
 
         [Test]
         public void DetectsMutualLeftRecursion()

--- a/src/Sprache.Tests/Scenarios/AssemblerTests.cs
+++ b/src/Sprache.Tests/Scenarios/AssemblerTests.cs
@@ -23,7 +23,7 @@ namespace Sprache.Tests.Scenarios
             from operands in AsmToken(Identifier).XDelimitedBy(Parse.Char(','))
             select Tuple.Create(instructionName, operands.ToArray());
 
-        public static CommentParser Comment = new CommentParser() { Single = ";" };
+        public static CommentParser Comment = new CommentParser { Single = ";", NewLine = Environment.NewLine };
 
         public static Parser<string> LabelId =
             Parse.Identifier(Parse.Letter.Or(Parse.Chars("._?")), Parse.LetterOrDigit.Or(Parse.Chars("_@#$~.?")));

--- a/src/Sprache.sln.DotSettings
+++ b/src/Sprache.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
I'd ideally like to change the signature of `Decimal()` to accept a `CultureInfo`, but instead this PR goes for the non-breaking option of introducing a new parser using the `*Invariant` naming convention found elsewhere in .NET. If nothing else, this should at least trigger caution when seen next to `Decimal` in IntelliSense.

Bundled some minor test and ReSharper-guided cleanup, apologies for the cluttered diff. @mikehadlow any chance of a quick sanity check? Cheers! :-)