### PR TITLE
Optimize the Parse.Regex method, add Parse.RegexMatch methods

### DIFF
--- a/src/Sprache.Tests/ParseTests.cs
+++ b/src/Sprache.Tests/ParseTests.cs
@@ -260,6 +260,26 @@ namespace Sprache.Tests
         }
 
         [Test]
+        public void RegexMatchParserConsumesInputOnSuccessfulMatch()
+        {
+            var digits = Parse.RegexMatch(@"\d(\d*)");
+            var r = digits.TryParse("123d");
+            Assert.IsTrue(r.WasSuccessful);
+            Assert.AreEqual("123", r.Value.Value);
+            Assert.AreEqual("23", r.Value.Groups[1].Value);
+            Assert.AreEqual(3, r.Remainder.Position);
+        }
+
+        [Test]
+        public void RegexMatchParserDoesNotConsumeInputOnFailedMatch()
+        {
+            var digits = Parse.RegexMatch(@"\d+");
+            var r = digits.TryParse("d123");
+            Assert.IsFalse(r.WasSuccessful);
+            Assert.AreEqual(0, r.Remainder.Position);
+        }
+
+        [Test]
         public void PositionedParser()
         {
             var pos = (from s in Parse.String("winter").Text()

--- a/src/Sprache.Tests/RegexTests.cs
+++ b/src/Sprache.Tests/RegexTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Sprache.Tests
+{
+    /// <summary>
+    /// These tests exist in order to verify that the modification that is applied to
+    /// the regex passed to every call to the <see cref="Parse.Regex(string,string)"/>
+    /// or <see cref="Parse.Regex(Regex,string)"/> methods does not change the results
+    /// in any way.
+    /// </summary>
+    public class RegexTests
+    {
+        private const string _startsWithCarrot = "^([a-z]{3})([0-9]{3})$";
+        private const string _alternation = "(this)|(that)|(the other)";
+
+        private static readonly MethodInfo _optimizeRegexMethod = typeof(Parse).GetMethod("OptimizeRegex", BindingFlags.NonPublic | BindingFlags.Static);
+
+        [Test]
+        public void OptimizedRegexIsNotSuccessfulWhenTheMatchIsNotAtTheBeginningOfTheInput()
+        {
+            var regexOriginal = new Regex("[a-z]+");
+            var regexOptimized = OptimizeRegex(regexOriginal);
+
+            const string input = "123abc";
+
+            Assert.That(regexOriginal.IsMatch(input), Is.True);
+            Assert.That(regexOptimized.IsMatch(input), Is.False);
+        }
+
+        [Test]
+        public void OptimizedRegexIsSuccessfulWhenTheMatchIsAtTheBeginningOfTheInput()
+        {
+            var regexOriginal = new Regex("[a-z]+");
+            var regexOptimized = OptimizeRegex(regexOriginal);
+
+            const string input = "abc123";
+
+            Assert.That(regexOriginal.IsMatch(input), Is.True);
+            Assert.That(regexOptimized.IsMatch(input), Is.True);
+        }
+
+        [TestCase(_startsWithCarrot, RegexOptions.None, "abc123", TestName = "Starts with ^, no options, success")]
+        [TestCase(_startsWithCarrot, RegexOptions.ExplicitCapture, "abc123", TestName = "Starts with ^, explicit capture, success")]
+        [TestCase(_startsWithCarrot, RegexOptions.None, "123abc", TestName = "Starts with ^, no options, failure")]
+        [TestCase(_startsWithCarrot, RegexOptions.ExplicitCapture, "123abc", TestName = "Starts with ^, explicit capture, failure")]
+        [TestCase(_alternation, RegexOptions.None, "abc123", TestName = "Alternation, no options, success")]
+        [TestCase(_alternation, RegexOptions.ExplicitCapture, "that", TestName = "Alternation, explicit capture, success")]
+        [TestCase(_alternation, RegexOptions.None, "that", TestName = "Alternation, no options, failure")]
+        [TestCase(_alternation, RegexOptions.ExplicitCapture, "that", TestName = "Alternation, explicit capture, failure")]
+        public void RegexOptimizationDoesNotChangeRegexBehavior(string pattern, RegexOptions options, string input)
+        {
+            var regexOriginal = new Regex(pattern, options);
+            var regexOptimized = OptimizeRegex(regexOriginal);
+
+            var matchOriginal = regexOriginal.Match(input);
+            var matchModified = regexOptimized.Match(input);
+
+            Assert.That(matchModified.Success, Is.EqualTo(matchOriginal.Success));
+            Assert.That(matchModified.Value, Is.EqualTo(matchOriginal.Value));
+            Assert.That(matchModified.Groups.Count, Is.EqualTo(matchOriginal.Groups.Count));
+
+            for (int i = 0; i < matchModified.Groups.Count; i++)
+            {
+                Assert.That(matchModified.Groups[i].Success, Is.EqualTo(matchOriginal.Groups[i].Success));
+                Assert.That(matchModified.Groups[i].Value, Is.EqualTo(matchOriginal.Groups[i].Value));
+            }
+        }
+
+        /// <summary>
+        /// Calls the <see cref="Parse.OptimizeRegex"/> method via reflection.
+        /// </summary>
+        private static Regex OptimizeRegex(Regex regex)
+        {
+            // Reflection isn't the best way of verifying behavior,
+            // but cluttering the public api sucks worse.
+
+            if (_optimizeRegexMethod == null)
+            {
+                throw new Exception("Unable to locate a private static method named " +
+                                    "\"OptimizeRegex\" in the Parse class. Has it been renamed?");
+            }
+
+            var optimizedRegex = (Regex)_optimizeRegexMethod.Invoke(null, new object[] { regex });
+            return optimizedRegex;
+        }
+    }
+}

--- a/src/Sprache.Tests/Sprache.Tests.csproj
+++ b/src/Sprache.Tests/Sprache.Tests.csproj
@@ -106,6 +106,7 @@
     <Compile Include="ParseTests.cs" />
     <Compile Include="PosAwareStr.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RegexTests.cs" />
     <Compile Include="ResultTests.cs" />
     <Compile Include="Scenarios\AmqpErrorTests.cs" />
     <Compile Include="Scenarios\AssemblerTests.cs" />

--- a/src/Sprache/Parse.Regex.cs
+++ b/src/Sprache/Parse.Regex.cs
@@ -28,6 +28,34 @@ namespace Sprache
         {
             if (regex == null) throw new ArgumentNullException("regex");
 
+            return RegexMatch(regex, description).Then(match => Return(match.Value));
+        }
+
+        /// <summary>
+        /// Construct a parser from the given regular expression, returning a parser of
+        /// type <see cref="Match"/>.
+        /// </summary>
+        /// <param name="pattern">The regex expression.</param>
+        /// <param name="description">Description of characters that don't match.</param>
+        /// <returns>A parser of regex match objects.</returns>
+        public static Parser<Match> RegexMatch(string pattern, string description = null)
+        {
+            if (pattern == null) throw new ArgumentNullException("pattern");
+
+            return RegexMatch(new Regex(pattern), description);
+        }
+
+        /// <summary>
+        /// Construct a parser from the given regular expression, returning a parser of
+        /// type <see cref="Match"/>.
+        /// </summary>
+        /// <param name="regex">The regex expression.</param>
+        /// <param name="description">Description of characters that don't match.</param>
+        /// <returns>A parser of regex match objects.</returns>
+        public static Parser<Match> RegexMatch(Regex regex, string description = null)
+        {
+            if (regex == null) throw new ArgumentNullException("regex");
+
             regex = OptimizeRegex(regex);
 
             var expectations = description == null
@@ -47,19 +75,19 @@ namespace Sprache
                         for (int j = 0; j < match.Length; j++)
                             remainder = remainder.Advance();
 
-                        return Result.Success(match.Value, remainder);
+                        return Result.Success(match, remainder);
                     }
 
                     var found = match.Index == input.Length
                                     ? "end of source"
                                     : string.Format("`{0}'", input[match.Index]);
-                    return Result.Failure<string>(
+                    return Result.Failure<Match>(
                         remainder,
                         "string matching regex `" + regex.ToString() + "' expected but " + found + " found",
                         expectations);
                 }
 
-                return Result.Failure<string>(i, "Unexpected end of input", expectations);
+                return Result.Failure<Match>(i, "Unexpected end of input", expectations);
             };
         }
 

--- a/src/Sprache/Parse.Regex.cs
+++ b/src/Sprache/Parse.Regex.cs
@@ -28,6 +28,8 @@ namespace Sprache
         {
             if (regex == null) throw new ArgumentNullException("regex");
 
+            regex = OptimizeRegex(regex);
+
             var expectations = description == null
                 ? new string[0]
                 : new[] { description };
@@ -40,7 +42,7 @@ namespace Sprache
                     var input = i.Source.Substring(i.Position);
                     var match = regex.Match(input);
 
-                    if (match.Success && match.Index == 0)
+                    if (match.Success)
                     {
                         for (int j = 0; j < match.Length; j++)
                             remainder = remainder.Advance();
@@ -59,6 +61,20 @@ namespace Sprache
 
                 return Result.Failure<string>(i, "Unexpected end of input", expectations);
             };
+        }
+
+        /// <summary>
+        /// Optimize the regex by only matching successfully at the start of the input.
+        /// Do this by wrapping the whole regex in non-capturing parentheses preceded by
+        ///  a `^'.
+        /// </summary>
+        /// <remarks>
+        /// This method is invoked via reflection in unit tests. If renamed, the tests
+        /// will need to be modified or they will fail.
+        /// </remarks>
+        private static Regex OptimizeRegex(Regex regex)
+        {
+            return new Regex(string.Format("^(?:{0})", regex), regex.Options);
         }
     }
 }


### PR DESCRIPTION
#### Optimize the Parse.Regex method

Create a new Regex based on the Regex parameter. Wrap the original pattern in non-capturing
parentheses preceded by a `^', while preserving the original Regex's options. This way, the
regex engine won't attempt to match the pattern at any position other than the beginning of
the input. This is done to match the way that Sprache parses input. Previously, a check was
made in the delegate returned by the Parse.Regex method in order to verify that the match's
Index was zero. This check is no longer necessary.

This is essentially what happens to the Regex parameter:

```c#
regex = new Regex(string.Format("^(?:{0})", regex), regex.Options);
```

#### Add Parse.RegexMatch methods

The new methods return a Parser<Match>, unlike the existing Parse.Regex methods, which
return a Parser<string>. Having a Match object as the return type opens up additional
scenarios, such as accessing its capture groups and invoking its Result method.