### PR TITLE
Fix TFMs for Xamarin.

### DIFF
--- a/Build/Sprache.proj
+++ b/Build/Sprache.proj
@@ -50,7 +50,7 @@
       
         <Delete Files="@(FilesToDelete)" />
     
-        <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(Package)\lib\portable-net4+netcore45+win8+wp8+sl5+MonoAndroid1+MonoTouch1" />
+        <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(Package)\lib\portable-net4+netcore45+win8+wp8+sl5+MonoAndroid+Xamarin.iOS10+MonoTouch" />
         
         <GetAssemblyIdentity AssemblyFiles="$(OutputDir)\Sprache.dll">
             <Output TaskParameter="Assemblies" ItemName="AsmInfo" />


### PR DESCRIPTION
This fixes the Target Framework Monikers for Xamarin. These got broken somewhere along the line and so Sprache is no longer installable into a Xamarin PCL. I blame NuGet 3, but I blame NuGet 3 for a lot of things.