### PR TITLE
Add .NET 3.5 and 4.0 targets

### DIFF
--- a/src/Sprache/Parse.Sequence.cs
+++ b/src/Sprache/Parse.Sequence.cs
@@ -91,16 +91,13 @@
                             ? "end of input"
                             : r.Remainder.Current.ToString();
 
-                        var msg = string.Format("Unexpected '{0}'", what);
-                        var exp = string.Format("'{0}' between {1} and {2} times, but found {3}", string.Join(", ", r.Expectations), 
-                            minimumCount, 
-                            maximumCount, 
-                            n);
+                        var msg = $"Unexpected '{what}'";
+                        var exp = $"'{StringExtensions.Join(", ", r.Expectations)}' between {minimumCount} and {maximumCount} times, but found {n}";
 
                         return Result.Failure<IEnumerable<T>>(i, msg, new[] { exp });
                     }
 
-                    if (remainder != r.Remainder)
+                    if (!ReferenceEquals(remainder, r.Remainder))
                     {
                         result.Add(r.Value);
                     }

--- a/src/Sprache/Parse.cs
+++ b/src/Sprache/Parse.cs
@@ -29,7 +29,7 @@ namespace Sprache
                         return Result.Success(i.Current, i.Advance());
 
                     return Result.Failure<char>(i,
-                        string.Format("unexpected '{0}'", i.Current),
+                        $"unexpected '{i.Current}'",
                         new[] { description });
                 }
 
@@ -68,7 +68,7 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<char> Chars(params char[] c)
         {
-            return Char(c.Contains, string.Join("|", c));
+            return Char(c.Contains, StringExtensions.Join("|", c));
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<char> Chars(string c)
         {
-            return Char(c.ToEnumerable().Contains, string.Join("|", c.ToCharArray()));
+            return Char(c.ToEnumerable().Contains, StringExtensions.Join("|", c.ToEnumerable()));
         }
 
 
@@ -100,7 +100,7 @@ namespace Sprache
         public static Parser<char> CharExcept(IEnumerable<char> c)
         {
             var chars = c as char[] ?? c.ToArray();
-            return CharExcept(chars.Contains, string.Join("|", chars));
+            return CharExcept(chars.Contains, StringExtensions.Join("|", chars));
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace Sprache
         /// <returns></returns> 
         public static Parser<char> CharExcept(string c)
         {
-            return CharExcept(c.ToEnumerable().Contains, string.Join("|", c.ToCharArray()));
+            return CharExcept(c.ToEnumerable().Contains, StringExtensions.Join("|", c.ToEnumerable()));
         }
 
         /// <summary>
@@ -215,7 +215,7 @@ namespace Sprache
 
                 if (result.WasSuccessful)
                 {
-                    var msg = string.Format("`{0}' was not expected", string.Join(", ", result.Expectations));
+                    var msg = $"`{StringExtensions.Join(", ", result.Expectations)}' was not expected";
                     return Result.Failure<object>(i, msg, new string[0]);
                 }
                 return Result.Success<object>(null, i);

--- a/src/Sprache/Sprache.xproj
+++ b/src/Sprache/Sprache.xproj
@@ -11,7 +11,6 @@
     <RootNamespace>Sprache</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Sprache/StringExtensions.cs
+++ b/src/Sprache/StringExtensions.cs
@@ -1,19 +1,32 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Sprache
 {
     internal static class StringExtensions
     {
-        // String does not implement IEnumerable<char> in portable subset (WinRT specifically)
         public static IEnumerable<char> ToEnumerable(this string @this)
         {
-            if (@this == null) throw new ArgumentNullException("@this");
+#if STRING_IS_ENUMERABLE
+            return @this;
+#else
+            if (@this == null) throw new ArgumentNullException(nameof(@this));
 
             for (var i = 0; i < @this.Length; ++i)
             {
                 yield return @this[i];
             }
+#endif
+        }
+
+        public static string Join<T>(string separator, IEnumerable<T> values)
+        {
+#if STRING_JOIN_ENUMERABLE
+            return string.Join(separator, values);
+#else
+            return string.Join(separator, values.Select(v => v.ToString()).ToArray());
+#endif
         }
     }
 }

--- a/src/Sprache/project.json
+++ b/src/Sprache/project.json
@@ -26,13 +26,25 @@
   },
 
   "frameworks": {
-    "net4.0": {},
+    "net3.5": {
+      "buildOptions": {
+        "define": [ "STRING_IS_ENUMERABLE" ]
+      }
+    },
+    "net4.0": {
+      "buildOptions": {
+        "define": [ "STRING_IS_ENUMERABLE", "STRING_JOIN_ENUMERABLE" ]
+      }
+    },
     "netstandard1.0": {
       "dependencies": {
-         "System.Globalization": "4.0.11",
-         "System.Linq": "4.1.0",
-         "System.Runtime": "4.1.0",
-         "System.Text.RegularExpressions": "4.1.0"
+        "System.Globalization": "4.0.11",
+        "System.Linq": "4.1.0",
+        "System.Runtime": "4.1.0",
+        "System.Text.RegularExpressions": "4.1.0"
+      },
+      "buildOptions": {
+        "define": [ "STRING_JOIN_ENUMERABLE" ]
       }
     }
   }

--- a/src/Sprache/project.json
+++ b/src/Sprache/project.json
@@ -26,7 +26,7 @@
   },
 
   "frameworks": {
-    "net45": {},
+    "net4.0": {},
     "netstandard1.0": {
       "dependencies": {
          "System.Globalization": "4.0.11",


### PR DESCRIPTION
#74.

I think this will omit Silverlight support (I'm okay with that), so revising the major version to 3.0 seems advisable (cc @droyad).
