### PR TITLE
Turn on XML documentation creation

### DIFF
--- a/src/Sprache/project.json
+++ b/src/Sprache/project.json
@@ -8,7 +8,7 @@
   "buildOptions": {
     "optimize": true,
     "outputName": "Sprache",
-    "xmlDoc": false
+    "xmlDoc": true
   },
 
   "packOptions": {


### PR DESCRIPTION
Not sure if we're generating much useful documentation, but at least outputting it is a start. As a follow-up we should turn on warnings-as-errors and get any undocumented items covered.