### PR TITLE
Remove Avalonia from list of Sprache users

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ The best place to start is [this introductory article](http://nblumhardt.com/201
  * The [XAML binding expression parser](https://github.com/OmniGUI/OmniXAML/blob/master/OmniXaml/InlineParsers/Extensions/MarkupExtensionParser.cs) in [OmniXaml](https://github.com/OmniGUI/OmniXAML), the cross-platform XAML implementation
  * The query parser in [Seq](https://getseq.net), a structured log server for .NET
  * The [connection string parser](https://github.com/EasyNetQ/EasyNetQ/blob/master/Source/EasyNetQ/ConnectionString/ConnectionStringGrammar.cs) in [EasyNetQ](http://easynetq.com/), a .NET API for RabbitMQ
- * The [markup parsers](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Markup/Avalonia.Markup.Xaml/Parsers/SelectorGrammar.cs) in [AvaloniaUI](https://github.com/AvaloniaUI/Avalonia), the multi-platform desktop .NET UI framework
  * [ApexSharp parser](https://github.com/apexsharp/apexparser/blob/master/ApexParser/Parser/ApexGrammar.cs), a two-way [Apex to C# transpiler](https://github.com/apexsharp/apexparser) (Salesforce programming language)
  * Sprache appears in the [credits for JetBrains ReSharper](https://confluence.jetbrains.com/display/ReSharper/Third-Party+Software+Shipped+With+ReSharper#Third-PartySoftwareShippedWithReSharper-Sprache)
 


### PR DESCRIPTION
Avalonia no longer uses Sprache: https://github.com/AvaloniaUI/Avalonia/commit/79f9158c6da1f53aff7a9012266f3b5feee94d03.

Would it be preferable to link to the older version of the file which did use Sprache, rather than removing the link to Avalonia altogether? 