### PR TITLE
Make newLine mandatory in CommentParser ctors

### DIFF
--- a/src/Sprache/CommentParser.cs
+++ b/src/Sprache/CommentParser.cs
@@ -48,7 +48,7 @@ namespace Sprache
         /// <param name="multiOpen"></param>
         /// <param name="multiClose"></param>
         /// <param name="newLine"></param>
-        public CommentParser(string multiOpen, string multiClose, string newLine = "\n")
+        public CommentParser(string multiOpen, string multiClose, string newLine)
         {
             Single = null;
             MultiOpen = multiOpen;
@@ -63,7 +63,7 @@ namespace Sprache
         /// <param name="multiOpen"></param>
         /// <param name="multiClose"></param>
         /// <param name="newLine"></param>
-        public CommentParser(string single, string multiOpen, string multiClose, string newLine = "\n")
+        public CommentParser(string single, string multiOpen, string multiClose, string newLine)
         {
             Single = single;
             MultiOpen = multiOpen;


### PR DESCRIPTION
This fixes #109 

Note that this does not break the CommentParser example in [XmlExample](https://github.com/sprache/Sprache/blob/develop/samples/XmlExample/Program.cs#L50).