### PR TITLE
ParseException exposing position

### DIFF
--- a/src/Sprache/ParseException.cs
+++ b/src/Sprache/ParseException.cs
@@ -23,10 +23,12 @@ namespace Sprache
         /// and the position where the error occured.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
-        /// <param name="input">The input that caused the error.</param>
-        public ParseException(string message, IInput input) : base(message)
+        /// <param name="position">The position where the error occured.</param>
+        public ParseException(string message, Position position) : base(message)
         {
-            Position = Position.FromInput(input);
+            if (position == null) throw new ArgumentNullException(nameof(position));
+
+            Position = position;
         }
 
         /// <summary>
@@ -39,11 +41,10 @@ namespace Sprache
         public ParseException(string message, Exception innerException) : base(message, innerException) { }
 
         /// <summary>
-        /// Gets the parsers positon.
+        /// Gets the position of the parsing failure if one is available; otherwise, null.
         /// </summary>
         public Position Position {
             get;
-            private set;
         }
     }
 }

--- a/src/Sprache/ParseException.cs
+++ b/src/Sprache/ParseException.cs
@@ -19,6 +19,17 @@ namespace Sprache
         public ParseException(string message) : base(message) { }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ParseException" /> class with a specified error message
+        /// and the position where the error occured.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="input">The input that caused the error.</param>
+        public ParseException(string message, IInput input) : base(message)
+        {
+            Position = Position.FromInput(input);
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ParseException" /> class with a specified error message 
         /// and a reference to the inner exception that is the cause of this exception.
         /// </summary>
@@ -26,5 +37,13 @@ namespace Sprache
         /// <param name="innerException">The exception that is the cause of the current exception, 
         /// or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
         public ParseException(string message, Exception innerException) : base(message, innerException) { }
+
+        /// <summary>
+        /// Gets the parsers positon.
+        /// </summary>
+        public Position Position {
+            get;
+            private set;
+        }
     }
 }

--- a/src/Sprache/ParserOfT.cs
+++ b/src/Sprache/ParserOfT.cs
@@ -48,7 +48,7 @@ namespace Sprache
             if(result.WasSuccessful)
                 return result.Value;
 
-            throw new ParseException(result.ToString(), result.Remainder);
+            throw new ParseException(result.ToString(), Position.FromInput(result.Remainder));
         }
     }
 }

--- a/src/Sprache/ParserOfT.cs
+++ b/src/Sprache/ParserOfT.cs
@@ -48,7 +48,7 @@ namespace Sprache
             if(result.WasSuccessful)
                 return result.Value;
 
-            throw new ParseException(result.ToString());
+            throw new ParseException(result.ToString(), result.Remainder);
         }
     }
 }

--- a/test/Sprache.Tests/ParseTests.cs
+++ b/test/Sprache.Tests/ParseTests.cs
@@ -425,6 +425,7 @@ namespace Sprache.Tests
             var repeated = Parse.Char('a').Repeat(4, 5);
 
             var expectedMessage = "Parsing failure: Unexpected 'end of input'; expected 'a' between 4 and 5 times, but found 3";
+            var expectedColumnPosition = 1;
 
             try
             {
@@ -433,6 +434,7 @@ namespace Sprache.Tests
             catch (ParseException ex)
             {
                 Assert.StartsWith(expectedMessage, ex.Message);
+                Assert.Equal(expectedColumnPosition, ex.Position.Column);
             }
         }
         
@@ -442,6 +444,7 @@ namespace Sprache.Tests
             var repeated = Parse.Char('a').Repeat(4);
 
             var expectedMessage = "Parsing failure: Unexpected 'end of input'; expected 'a' 4 times, but found 3";
+            var expectedColumnPosition = 1;
 
             try
             {
@@ -450,6 +453,7 @@ namespace Sprache.Tests
             catch(ParseException ex)
             {
                 Assert.StartsWith(expectedMessage, ex.Message);
+                Assert.Equal(expectedColumnPosition, ex.Position.Column);
             }
         }
 

--- a/test/Sprache.Tests/Scenarios/ExpressionGrammarTests.cs
+++ b/test/Sprache.Tests/Scenarios/ExpressionGrammarTests.cs
@@ -12,6 +12,8 @@ namespace Sprache.Tests.Scenarios
             const string input = "1 + (2 * 3";
             var x = Assert.Throws<ParseException>(() => ExpressionParser.ParseExpression(input));
             Assert.Contains("expected )", x.Message);
+            Assert.Equal(1, x.Position.Line);
+            Assert.Equal(11, x.Position.Column);
         }
 
         [Fact]
@@ -20,6 +22,8 @@ namespace Sprache.Tests.Scenarios
             const string input = "1 + * 3";
             var x = Assert.Throws<ParseException>(() => ExpressionParser.ParseExpression(input));
             Assert.DoesNotContain("expected end of input", x.Message);
+            Assert.Equal(1, x.Position.Line);
+            Assert.Equal(5, x.Position.Column);
         }    
     }
 


### PR DESCRIPTION
ParseException now explicitly exposes the Position where the parsing error occurred.