### PR TITLE
Overload operators for syntactic sugar

### DIFF
--- a/samples/XmlExample/Program.cs
+++ b/samples/XmlExample/Program.cs
@@ -86,11 +86,11 @@ namespace XmlExample
                                                      from slash in Parse.Char('/')
                                                      select new Node { Name = id });
 
-        static readonly Parser<Node> Node = ShortNode.Or(FullNode);
+        static readonly Parser<Node> Node = ShortNode | FullNode;
 
         static readonly Parser<Item> Item =
             from leading in Comment.MultiLineComment.Many()
-            from item in Node.Select(n => (Item)n).XOr(Content)
+            from item in Node.Select(n => (Item)n).XOr(Content.Select(c => (Item)c))
             from trailing in Comment.MultiLineComment.Many()
             select item;
 

--- a/src/Sprache/CommentParser.cs
+++ b/src/Sprache/CommentParser.cs
@@ -116,7 +116,7 @@ namespace Sprache
             get
             {
                 if (Single != null && MultiOpen != null && MultiClose != null)
-                    return SingleLineComment.Or(MultiLineComment);
+                    return SingleLineComment | MultiLineComment;
                 else if (Single != null && (MultiOpen == null || MultiClose == null))
                     return SingleLineComment;
                 else if (Single == null && (MultiOpen != null && MultiClose != null))

--- a/src/Sprache/Parse.Commented.cs
+++ b/src/Sprache/Parse.Commented.cs
@@ -31,9 +31,9 @@ namespace Sprache
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));
 
-            return i =>
+            return new Parser<ITextSpan<T>>(i =>
             {
-                var r = parser(i);
+                var r = parser.TryParse(i);
                 if (r.WasSuccessful)
                 {
                     var span = new TextSpan<T>
@@ -48,7 +48,7 @@ namespace Sprache
                 }
 
                 return Result.Failure<ITextSpan<T>>(r.Remainder, r.Message, r.Expectations);
-            };
+            });
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Sprache
                 let trailingCount = trailingPreview.GetOrElse(Enumerable.Empty<ITextSpan<string>>())
                     .Where(c => IsSameLine(valueSpan, c)).Count()
                 from trailingComments in commentSpan.Repeat(trailingCount)
-                select new CommentedValue<T>(leadingComments, valueSpan.Value, trailingComments.Select(c => c.Value));
+                select (ICommented<T>) new CommentedValue<T>(leadingComments, valueSpan.Value, trailingComments.Select(c => c.Value));
         }
     }
 }

--- a/src/Sprache/Parse.Optional.cs
+++ b/src/Sprache/Parse.Optional.cs
@@ -17,15 +17,15 @@ namespace Sprache
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));
 
-            return i =>
+            return new Parser<IOption<T>>(i =>
             {
-                var pr = parser(i);
+                var pr = parser.TryParse(i);
 
                 if (pr.WasSuccessful)
                     return Result.Success(new Some<T>(pr.Value), pr.Remainder);
 
                 return Result.Success(new None<T>(), i);
-            };
+            });
         }
 
         /// <summary>
@@ -39,9 +39,9 @@ namespace Sprache
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));
 
-            return i =>
+            return new Parser<IOption<T>>(i =>
             {
-                var result = parser(i);
+                var result = parser.TryParse(i);
 
                 if (result.WasSuccessful)
                     return Result.Success(new Some<T>(result.Value), result.Remainder);
@@ -50,7 +50,7 @@ namespace Sprache
                     return Result.Success(new None<T>(), i);
 
                 return Result.Failure<IOption<T>>(result.Remainder, result.Message, result.Expectations);
-            };
+            });
         }
 
         /// <summary>
@@ -66,15 +66,15 @@ namespace Sprache
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));
 
-            return i =>
+            return new Parser<IOption<T>>(i =>
             {
-                var result = parser(i);
+                var result = parser.TryParse(i);
 
                 if (result.WasSuccessful)
                     return Result.Success(new Some<T>(result.Value), i);
 
                 return Result.Success(new None<T>(), i);
-            };
+            });
         }
     }
 }

--- a/src/Sprache/Parse.Positioned.cs
+++ b/src/Sprache/Parse.Positioned.cs
@@ -12,16 +12,18 @@ namespace Sprache
         /// <returns></returns>
         public static Parser<T> Positioned<T>(this Parser<T> parser) where T : IPositionAware<T>
         {
-            return i =>
+            return new Parser<T>(i =>
             {
-                var r = parser(i);
+                var r = parser.TryParse(i);
 
                 if (r.WasSuccessful)
                 {
-                    return Result.Success(r.Value.SetPos(Position.FromInput(i), r.Remainder.Position - i.Position), r.Remainder);
+                    return Result.Success(r.Value.SetPos(Position.FromInput(i), r.Remainder.Position - i.Position),
+                        r.Remainder);
                 }
+
                 return r;
-            };
+            });
         }
     }
 }

--- a/src/Sprache/Parse.Primitives.cs
+++ b/src/Sprache/Parse.Primitives.cs
@@ -15,10 +15,7 @@
         /// line ending or end of input
         /// </summary>
         public static Parser<string> LineTerminator =
-            Return("").End()
-                .Or(LineEnd.End())
-                .Or(LineEnd)
-                .Named("LineTerminator");
+            Return("").End() | LineEnd.End() | LineEnd.Named("LineTerminator");
 
         /// <summary>
         /// Parser for identifier starting with <paramref name="firstLetterParser"/> and continuing with <paramref name="tailLetterParser"/>

--- a/src/Sprache/Parse.Regex.cs
+++ b/src/Sprache/Parse.Regex.cs
@@ -62,7 +62,7 @@ namespace Sprache
                 ? new string[0]
                 : new[] { description };
 
-            return i =>
+            return new Parser<Match>(i =>
             {
                 if (!i.AtEnd)
                 {
@@ -88,7 +88,7 @@ namespace Sprache
                 }
 
                 return Result.Failure<Match>(i, "Unexpected end of input", expectations);
-            };
+            });
         }
 
         /// <summary>

--- a/src/Sprache/Parse.Sequence.cs
+++ b/src/Sprache/Parse.Sequence.cs
@@ -76,14 +76,14 @@
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));
 
-            return i =>
+            return new Parser<IEnumerable<T>>(i =>
             {
                 var remainder = i;
                 var result = new List<T>();
 
                 for (var n = 0; n < maximumCount; ++n)
                 {
-                    var r = parser(remainder);
+                    var r = parser.TryParse(remainder);
 
                     if (!r.WasSuccessful && n < minimumCount)
                     {
@@ -108,7 +108,7 @@
                 }
 
                 return Result.Success<IEnumerable<T>>(result, remainder);
-            };
+            });
         }
 
         /// <summary>

--- a/test/Sprache.Tests/ParseTests.cs
+++ b/test/Sprache.Tests/ParseTests.cs
@@ -134,7 +134,7 @@ namespace Sprache.Tests
         {
             var first = Parse.Char('a').Once().Concat(Parse.Char('b').Once());
             var second = Parse.Char('a').Once();
-            var p = first.Or(second);
+            var p = first | second;
             AssertParser.SucceedsWithAll(p, "a");
         }
 
@@ -145,12 +145,11 @@ namespace Sprache.Tests
             AssertParser.SucceedsWithAll(p, "abc");
         }
 
-        static readonly Parser<IEnumerable<char>> ASeq =
+        private static readonly Parser<IEnumerable<char>> ASeq =
             (from first in Parse.Ref(() => ASeq)
-             from comma in Parse.Char(',')
-             from rest in Parse.Char('a').Once()
-             select first.Concat(rest))
-            .Or(Parse.Char('a').Once());
+                from comma in Parse.Char(',')
+                from rest in Parse.Char('a').Once()
+                select first.Concat(rest)) | Parse.Char('a').Once();
 
         [Fact]
         public void DetectsLeftRecursion()
@@ -161,14 +160,12 @@ namespace Sprache.Tests
         static readonly Parser<IEnumerable<char>> ABSeq =
             (from first in Parse.Ref(() => BASeq)
              from rest in Parse.Char('a').Once()
-             select first.Concat(rest))
-            .Or(Parse.Char('a').Once());
+             select first.Concat(rest)) | Parse.Char('a').Once();
 
         static readonly Parser<IEnumerable<char>> BASeq =
             (from first in Parse.Ref(() => ABSeq)
              from rest in Parse.Char('b').Once()
-             select first.Concat(rest))
-            .Or(Parse.Char('b').Once());
+             select first.Concat(rest)) | Parse.Char('b').Once();
 
         [Fact]
         public void DetectsMutualLeftRecursion()

--- a/test/Sprache.Tests/Scenarios/AmqpErrorTests.cs
+++ b/test/Sprache.Tests/Scenarios/AmqpErrorTests.cs
@@ -27,7 +27,7 @@ namespace Sprache.Tests.Scenarios
             select new IntValue(int.Parse(x));
 
         static readonly Parser<Value> value =
-            stringValue.Or<Value>(intValue);
+            stringValue.Select(s => (Value)s).Or<Value>(intValue.Select(s => (Value)s));
 
         static readonly Parser<string> key =
             Parse.AnyChar.Except(keyValueDelimiter).Except(itemSeparator).XMany().Text();
@@ -43,7 +43,7 @@ namespace Sprache.Tests.Scenarios
             select new AmqpStringItem(x);
 
         static readonly Parser<AmqpErrorItem> item =
-            keyValue.Or<AmqpErrorItem>(itemContent);
+            keyValue.Select(s => (AmqpErrorItem)s) | itemContent.Select(s => (AmqpErrorItem)s);
 
         private static readonly Parser<IEnumerable<AmqpErrorItem>> items =
             from leading in item

--- a/test/Sprache.Tests/Scenarios/AssemblerTests.cs
+++ b/test/Sprache.Tests/Scenarios/AssemblerTests.cs
@@ -26,7 +26,7 @@ namespace Sprache.Tests.Scenarios
         public static CommentParser Comment = new CommentParser { Single = ";", NewLine = Environment.NewLine };
 
         public static Parser<string> LabelId =
-            Parse.Identifier(Parse.Letter.Or(Parse.Chars("._?")), Parse.LetterOrDigit.Or(Parse.Chars("_@#$~.?")));
+            Parse.Identifier(Parse.Letter | Parse.Chars("._?"), Parse.LetterOrDigit | Parse.Chars("_@#$~.?"));
 
         public static Parser<string> Label =
             from labelName in AsmToken(LabelId)

--- a/test/Sprache.Tests/Scenarios/CsvTests.cs
+++ b/test/Sprache.Tests/Scenarios/CsvTests.cs
@@ -21,7 +21,7 @@ namespace Sprache.Tests.Scenarios
         }
 
         static readonly Parser<char> QuotedCellContent =
-            Parse.AnyChar.Except(QuotedCellDelimiter).Or(Escaped(QuotedCellDelimiter));
+            Parse.AnyChar.Except(QuotedCellDelimiter) | Escaped(QuotedCellDelimiter);
 
         static readonly Parser<char> LiteralCellContent =
             Parse.AnyChar.Except(CellSeparator).Except(Parse.String(Environment.NewLine));
@@ -36,9 +36,7 @@ namespace Sprache.Tests.Scenarios
             Parse.String(Environment.NewLine).Text();
 
         static readonly Parser<string> RecordTerminator =
-            Parse.Return("").End().XOr(
-            NewLine.End()).Or(
-            NewLine);
+            Parse.Return("").End().XOr(NewLine.End()) | NewLine;
 
         static readonly Parser<string> Cell =
             QuotedCell.XOr(

--- a/test/Sprache.Tests/Scenarios/ExpressionGrammarTests.cs
+++ b/test/Sprache.Tests/Scenarios/ExpressionGrammarTests.cs
@@ -46,7 +46,7 @@ namespace Sprache.Tests.Scenarios
 
         static readonly Parser<Expression> Constant =
              Parse.Decimal
-             .Select(x => Expression.Constant(double.Parse(x)))
+             .Select(x => (Expression)Expression.Constant(double.Parse(x)))
              .Named("number");
 
         static readonly Parser<Expression> Factor =
@@ -59,7 +59,7 @@ namespace Sprache.Tests.Scenarios
         static readonly Parser<Expression> Operand =
             ((from sign in Parse.Char('-')
               from factor in Factor
-              select Expression.Negate(factor)
+              select (Expression)Expression.Negate(factor)
              ).XOr(Factor)).Token();
 
         static readonly Parser<Expression> Term = Parse.XChainOperator(Multiply.XOr(Divide), Operand, Expression.MakeBinary);


### PR DESCRIPTION
Closes #130 

**This is a proof of concept to show that it's possible.**

In this PR I replaced all occurrences of `.Or()` with pipe operator (`ParserA | ParserB`) and I believe this improves code comprehension by a lot. As the result of converting `Parser<T>` to a class, its type parameter is no longer covariant, but I think that's largely fine because in some cases there was a problem with it anyway.

If we choose to go in this direction, I will improve this PR by refactoring the code and adding other operators as well.