### PR TITLE
Allow advancing Input by arbitrary delta

### DIFF
--- a/src/Sprache/IInput.cs
+++ b/src/Sprache/IInput.cs
@@ -11,11 +11,18 @@ namespace Sprache
     public interface IInput : IEquatable<IInput>
     {
         /// <summary>
-        /// Advances the input.
+        /// Advances the input by one character.
         /// </summary>
         /// <returns>A new <see cref="IInput" /> that is advanced.</returns>
         /// <exception cref="System.InvalidOperationException">The input is already at the end of the source.</exception>
         IInput Advance();
+
+        /// <summary>
+        /// Advances the input by given number of characters.
+        /// </summary>
+        /// <returns>A new <see cref="IInput" /> that is advanced.</returns>
+        /// <exception cref="System.InvalidOperationException">The input is already at the end of the source.</exception>
+        IInput Advance(int delta);
 
         /// <summary>
         /// Gets the whole source.

--- a/src/Sprache/Input.cs
+++ b/src/Sprache/Input.cs
@@ -37,17 +37,36 @@ namespace Sprache
             Memos = new Dictionary<object, object>();
         }
 
-        /// <summary>
-        /// Advances the input.
-        /// </summary>
-        /// <returns>A new <see cref="IInput" /> that is advanced.</returns>
-        /// <exception cref="System.InvalidOperationException">The input is already at the end of the source.</exception>
-        public IInput Advance()
+        /// <inheritdoc />
+        public IInput Advance() => Advance(1);
+
+        /// <inheritdoc />
+        public IInput Advance(int delta)
         {
             if (AtEnd)
                 throw new InvalidOperationException("The input is already at the end of the source.");
+            if (delta <= 0)
+                throw new InvalidOperationException($"The input can't advance by {delta}, need a positive number.");
+            if (Position + delta > Source.Length)
+                throw new InvalidOperationException($"The input can't advance by {delta} because it exceeds the bounds of the source.");
 
-            return new Input(_source, _position + 1, Current == '\n' ? _line + 1 : _line, Current == '\n' ? 1 : _column + 1);
+            var line = Line;
+            var column = Column;
+
+            for (var i = Position; i < Position + delta; i++)
+            {
+                if (Source[i] == '\n')
+                {
+                    line++;
+                    column = 1;
+                }
+                else
+                {
+                    column++;
+                }
+            }
+
+            return new Input(Source, Position + delta, line, column);
         }
 
         /// <summary>

--- a/src/Sprache/Parse.Regex.cs
+++ b/src/Sprache/Parse.Regex.cs
@@ -72,8 +72,7 @@ namespace Sprache
 
                     if (match.Success)
                     {
-                        for (int j = 0; j < match.Length; j++)
-                            remainder = remainder.Advance();
+                        remainder = remainder.Advance(match.Length);
 
                         return Result.Success(match, remainder);
                     }


### PR DESCRIPTION
It often happens that a parser needs to advance the input by more than just 1 position. A good example of such built-in parser is `Parse.Regex`, but I also have some of my own could make use of it.

Calling `Advance()` multiple times in a loop causes a lot of completely unnecessary allocations that can be easily avoided.

I implemented this in the least obtrusive way, in my opinion. There are also options to use an optional parameter instead of an overload (not backwards compatible) or make an extension method that uses the `internal` constructor of `Input` (dirty hack).