### PR TITLE
Fix #129 Exception when Parse.Ref occurs in Parse.Or

### DIFF
--- a/src/Sprache/Parse.cs
+++ b/src/Sprache/Parse.cs
@@ -388,7 +388,12 @@ namespace Sprache
                                p = reference();
 
                            if (i.Memos.ContainsKey(p))
-                               throw new ParseException(i.Memos[p].ToString());
+                           {
+                               var pResult = i.Memos[p] as IResult<T>;
+                               if (pResult.WasSuccessful)
+                                   return pResult;
+                               throw new ParseException(pResult.ToString());
+                           }
 
                            i.Memos[p] = Result.Failure<T>(i,
                                "Left recursion in the grammar.",


### PR DESCRIPTION
When using Parse.Ref inside Parse.Or, Sprache throws an exception in the style of `Sprache.ParseException: Successful parsing of members.`

This PR fixes this error and returns the actual value if the parsing was successful.