### PR TITLE
Fix CommentParser eol issue #184

### DIFF
--- a/src/Sprache/CommentParser.cs
+++ b/src/Sprache/CommentParser.cs
@@ -77,7 +77,7 @@
                     throw new ParseException("Field 'Single' is null; single-line comments not allowed.");
 
                 return from first in Parse.String(Single)
-                       from rest in Parse.CharExcept(NewLine).Many().Text()
+                       from rest in Parse.CharExcept(new[] {'\r', '\n' }).Many().Text()
                        select rest;
             }
             private set { }

--- a/test/Sprache.Tests/CommentParserTest.cs
+++ b/test/Sprache.Tests/CommentParserTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Sprache.Tests
+{
+    public class CommentParserTest
+    {
+        [Fact]
+        public void Check_single_line_comment_for_both_eol_windows_linux()
+        {
+            var parser = new CommentParser();
+            var expected = "this is a line comment";
+            var result = parser.SingleLineComment.Parse("//this is a line comment\r\nint i=5;");
+            Assert.Equal(result, expected);
+            result = parser.SingleLineComment.Parse("//this is a line comment\nint i=5;");
+            Assert.Equal(result, expected);
+
+        }
+        [Fact]
+        public void Check_any_comment_for_both_eol_windows_linux()
+        {
+            var parser = new CommentParser();
+            var expected = "this is a line comment";
+            var result = parser.AnyComment.Parse("//this is a line comment\r\nint i=5;");
+            Assert.Equal(result, expected);
+            result = parser.AnyComment.Parse("//this is a line comment\nint i=5;");
+            Assert.Equal(result, expected);
+
+        }
+    }
+}


### PR DESCRIPTION
Fix #184 NewLine in CommentParser for  Linux/Windows Environment.
Also, the PR fix a fail of test case when running the test project  in Linux (Ubuntu 18.04)
```
Sprache.Tests.Scenarios.AssemblerTests.CanParseSeceralLines [FAIL]
  Failed Sprache.Tests.Scenarios.AssemblerTests.CanParseSeceralLines [3 ms]
  Error Message:
   Assert.Equal() Failure
```